### PR TITLE
Use ansible_env instead of lookup

### DIFF
--- a/tasks/wowza.yml
+++ b/tasks/wowza.yml
@@ -1,11 +1,11 @@
 ---
 - name: Get Wowza ({{ wowza_installer }})
-  get_url: url={{ wowza_download_path }}{{ wowza_installer }} dest={{ lookup('env', 'HOME') }}/{{ wowza_installer }} mode=0755 owner={{ lookup('env', 'USER') }}
+  get_url: url={{ wowza_download_path }}{{ wowza_installer }} dest={{ ansible_env.HOME }}/{{ wowza_installer }} mode=0755 owner={{ ansible_env.USER  }}
 - name: install expect
   apt: name={{ item }} update_cache=yes
   with_items: "{{ the_expectables }}"
 - name: push expect templates
-  template: src=script.exp.j2 dest={{ lookup('env', 'HOME') }}/script.exp mode=0755 owner={{ lookup('env', 'USER') }}
+  template: src=script.exp.j2 dest={{ ansible_env.HOME  }}/script.exp mode=0755 owner={{ ansible_env.USER }}
 - name: Run expect script, which runs Wowza installer
   args:
     creates: /usr/local/WowzaStreamingEngine/conf/Server.license


### PR DESCRIPTION
Lookup (atleast on the mac I'm using), is using the local servers environment settings, rather than the facts obtained on the remote server via gather_facts.

Before these changes, I was getting "Not writable" errors because I was trying to write to a home directory on linux which is in the Mac /Users/something format.